### PR TITLE
opt-out header icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ import ParallaxScrollView from 'react-native-parallax-scrollview';
 | userImage | http://i.imgur.com/uma9OfG.jpg | string | The user image displayed in the collapsable header view |
 | userTitle | Engineering Manager | string | The user title displayed in the collapsable header view |
 | headerView | Profile View | custom object | Pass in a custom object to override the default header view |
-| leftIcon | menu | object | Pass in the left icon name and type as an object. ```leftIcon={{name: 'rocket', color: 'red', size: 30, type: 'font-awesome'}}```|
+| leftIcon | none | object | Pass in the left icon name and type as an object. ```leftIcon={{name: 'rocket', color: 'red', size: 30, type: 'font-awesome'}}```|
 | leftIconOnPress | none | callback | Callback function when the left icon is pressed |
-| rightIcon | present | object | Pass in the right icon name and type etc as an object. ```rightIcon={{name: 'user', color: 'blue', size: 30, type: 'font-awesome'}}```|
+| rightIcon | none | object | Pass in the right icon name and type etc as an object. ```rightIcon={{name: 'user', color: 'blue', size: 30, type: 'font-awesome'}}```|
 | rightIconOnPress | none | callback | Callback function when the right icon is pressed |
 | *children* | List View | React Components | Render any react views/components as children and these will be rendered below the headerView |
 

--- a/src/ParallaxScrollView.js
+++ b/src/ParallaxScrollView.js
@@ -142,6 +142,7 @@ export default class ParallaxScrollView extends Component {
           })
         }}
       >
+      {leftIcon &&
         <View
           style={{
             flex: 1,
@@ -159,6 +160,7 @@ export default class ParallaxScrollView extends Component {
             underlayColor='transparent'
           />
         </View>
+      }
         <View
           style={{
             flex: 5,
@@ -170,6 +172,7 @@ export default class ParallaxScrollView extends Component {
         >
           {this.renderNavBarTitle()}
         </View>
+      {rightIcon &&         
         <View
           style={{
             flex: 1,
@@ -187,6 +190,7 @@ export default class ParallaxScrollView extends Component {
             underlayColor='transparent'
           />
         </View>
+      }
       </Animated.View>
     );
   }


### PR DESCRIPTION
in some cases, we don't need the `leftIcon` and `rightIcon`. This PR will allow users to opt-out those icon if the properties are not present